### PR TITLE
controller.ino rewritten to work with 20 km/h firmware

### DIFF
--- a/LimeIoT/controller.ino
+++ b/LimeIoT/controller.ino
@@ -9,37 +9,69 @@ void readController() {
   if (currentMillis - previousMillis >= interval) {
     previousMillis = currentMillis;
 
-    if (Serial.available() == 42) {
-      byte command[42];
-      Serial.readBytes(command, 42);
-
-      pDebugCharacteristic->setValue(command, sizeof(command));
-      pDebugCharacteristic->notify();
-
-      uint16_t new_checksum = crc16(command, sizeof(command) - 2, 0x1021, 0x0000, 0x0000, false, false);
-      uint16_t old_checksum = (uint16_t(command[40]) << 8) | uint16_t(command[41]);  // get a pointer to the last two bytes of the command array and interpret them as a uint16_t
-
-      // Check if the cammand has correct checksum
-      if (old_checksum == new_checksum) {
-        speed = (command[8] / 172.0) * max_speed;
-        battery = command[19];
-        throttle = command[28];
-        isCharging = command[21];
-        isUnlocked = command[23] == 0xF1 ? 1 : 0;
-        lightIsOn = command[29] == 0x4D ? 1 : 0;
+    while (Serial.available() > 0 && Serial.peek() != 0x46) {
+      if (millis() - previousMillis >= interval) {
+        return;
       }
-    } else {
+      Serial.read();
+    }
+
+    byte command[44];
+    if (Serial.available() >= 6) {
+      for (int i = 0; i < 6; i++) {
+        command[i] = Serial.read();
+      }
+      if (command[4] == 0x00) {
+
+        int msgLen = command[5];
+        uint32_t id = (uint32_t(command[0]) << 24) |
+                      (uint32_t(command[1]) << 16) |
+                      (uint32_t(command[2]) <<  8) |
+                       uint32_t(command[3]);
+
+        if (msgLen <= 0x24 && Serial.available() >= msgLen + 2) {
+          for (int i = 0; i < msgLen + 2; i++) {
+            command[i+6] = Serial.read();
+          }
+          for (int i = msgLen + 8; i < 44; i++) {
+            command[i] = 0;
+          }
+        }
+
+        pDebugCharacteristic->setValue(command, msgLen + 2);
+        pDebugCharacteristic->notify();
+
+        uint16_t new_checksum = crc16(command, msgLen + 6, 0x1021, 0x0000, 0x0000, false, false);
+        uint16_t old_checksum = (uint16_t(command[msgLen + 6]) << 8) | uint16_t(command[msgLen + 7]);  // get a pointer to the last two bytes of the command array and interpret them as a uint16_t
+
+        // Check if the command has correct checksum
+        if (old_checksum == new_checksum) {
+          switch (id) {
+            case 0x46580CFF:
+              speed = (max_speed == 20) ? command[8] * max_speed / 119 : command[8] * max_speed / 172;
+              battery = command[19];
+              throttle = command[28];
+              isCharging = command[21];
+              isUnlocked = command[23] & 0x01;
+              lightIsOn = command[29] & 0x01;
+              break;
+          }
+        }
+      }
     }
     while (Serial.available() > 0) {
-      char t = Serial.read();
+      Serial.read();
     }
   }
 }
 
 void sendControllerCommand(byte* cmd, size_t len) {
-  while(isSending);
-  isSending = true;
+  static bool isSending = 0;
+  while (isSending) {
+    delay(100);
+  }
+  isSending = 1;
   Serial.write(cmd, len);
-  delay(100);
-  isSending = false;
+  delay(500);
+  isSending = 0;
 }


### PR DESCRIPTION
fixed issue with 20 km/h firmware which is sending more noise than the 25 km/h firmware. the code now scans for start code 0x46. message is interpreted as explained in #6 and only processed if the pattern matches 4 byte header + zero byte + frame length. the 4 byte header is used as identifier for the switch case.